### PR TITLE
added support for incremental builds

### DIFF
--- a/cactus/cli.py
+++ b/cactus/cli.py
@@ -59,10 +59,10 @@ class CactusCli(object):
         site = self.Site(path, config)
         site.make_messages()
 
-    def serve(self, path, config, port, browser):
+    def serve(self, path, config, port, browser, incremental):
         """Serve the project and watch changes"""
         site = self.Site(path, config)
-        site.serve(port=port, browser=browser)
+        site.serve(port=port, browser=browser, incremental=incremental)
 
     def domain_setup(self, path, config):
         site = self.Site(path, config)
@@ -97,6 +97,7 @@ def main(args):
     parser_serve.set_defaults(target=cli.serve)
     parser_serve.add_argument('-p', '--port', default=8000, type=int, help='The port on which to serve the site.')
     parser_serve.add_argument('-b', '--browser', action='store_true', help='Whether to open a browser for the site.')
+    parser_serve.add_argument('-i', '--incremental', action='store_true', help='Whether it should only re-build changed files.')
 
     parser_make_messages = subparsers.add_parser('messages:make', help='Create translation files for the current project')
     parser_make_messages.set_defaults(target=cli.make_messages)

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -18,6 +18,7 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
     discarded = False
 
     def __init__(self, site, source_path):
+        self._render_cache = None
         self.site = site
 
         # The path where this element should be linked in "base" pages
@@ -91,7 +92,15 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
 
         return Context(context)
 
+    def clear_cache(self):
+        self._render_cache = None
+
     def render(self):
+        if not self._render_cache:
+            self._render_cache = self._render()
+        return self._render_cache
+
+    def _render(self):
         """
         Takes the template data with context and renders it to the final output file.
         """

--- a/cactus/tests/test_template_tags.py
+++ b/cactus/tests/test_template_tags.py
@@ -171,6 +171,7 @@ class TestMarkdown(SiteTestCase):
             with open(os.path.join(self.site.page_path, "test.html"), "w") as f:
                 f.write("{% filter markdown %}" + levelStr + " Hello{% endfilter %}")
 
+            self.site.clear_page_cache()
             self.site.build()
 
             with open(os.path.join(self.site.build_path, "test.html")) as f:


### PR DESCRIPTION
you can invoke the incremental build for local development using the `-i` command line argument

this option only re-builds files that changed. this may be useful when working with single files mainly (e.g. when writing articles).

``` console
$ bin/cactus serve -i
```
